### PR TITLE
Change value of parameter `library-manger` to `update`.

### DIFF
--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -22,5 +22,5 @@ jobs:
         uses: arduino/arduino-lint-action@v1
         with:
           compliance: specification
-          library-manager: submit
+          library-manager: update
           project-type: library


### PR DESCRIPTION
This is necessary since the library already has been added to Arduino's library index manager.